### PR TITLE
added --output_dir argument  in predict.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ python3 predict.py --path_to_dataset $DATASET_PATH --path_to_model MODEL_PATH --
 eg.
 
 ```
-python3 predict.py --path_to_dataset data.hdf5 --path_to_model TIMED.h5 --output_dir test_outputs
+python3 predict.py --path_to_dataset data.hdf5 --path_to_model TIMED.h5 --output_dir .
 ```
 
 ### 1.3 Predicting Rotamers

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ For example, download TIMED.h5 . Make sure to place it in this directory.
 
 
 ```
-python3 predict.py --path_to_dataset $DATASET_PATH --path_to_model MODEL_PATH
+python3 predict.py --path_to_dataset $DATASET_PATH --path_to_model MODEL_PATH --output_dir OUTPUT_DIRECTORY
 ```
 
 eg.
 
 ```
-python3 predict.py --path_to_dataset data.hdf5 --path_to_model TIMED.h5
+python3 predict.py --path_to_dataset data.hdf5 --path_to_model TIMED.h5 --output_dir test_outputs
 ```
 
 ### 1.3 Predicting Rotamers

--- a/design_utils/utils.py
+++ b/design_utils/utils.py
@@ -1,4 +1,4 @@
-import gzip, sys, random, string, os
+import gzip, sys, random, string
 import typing as t
 import warnings
 from itertools import product
@@ -554,7 +554,7 @@ def convert_dataset_map_for_srb(flat_dataset_map: list, model_name: str, output_
 
         count_dict[pdb] += 1
     
-    txt_file_path = os.path.join(output_dir, f"{model_name}.txt")
+    txt_file_path = Path(output_dir) / f"{model_name}.txt"
     with open(txt_file_path, "w") as d:
         d.write("ignore_uncommon False\ninclude_pdbs\n##########\n")
         for pdb, count in count_dict.items():
@@ -594,7 +594,7 @@ def save_dict_to_fasta(pdb_to_sequence: dict, model_name: str, output_dir: str):
     output_dir: str
         Directory where the fasta file will be saved.
     """
-    fasta_file_path = os.path.join(output_dir, f"{model_name}.fasta")
+    fasta_file_path = Path(output_dir) / f"{model_name}.fasta"
 
     with open(fasta_file_path, "w") as f:
         for pdb, seq in pdb_to_sequence.items():
@@ -739,10 +739,9 @@ def save_outputs_to_file(
     model_name: str
         Name of the model being used.
     """
-
-    encoded_labels_path = os.path.join(output_dir, "encoded_labels.csv")
-    datasetmap_path = os.path.join(output_dir, "datasetmap.txt")
-    predictions_path = os.path.join(output_dir, f"{model_name}.csv")
+    encoded_labels_path = Path(output_dir) / "encoded_labels.csv"
+    datasetmap_path = Path(output_dir) / "datasetmap.txt"
+    predictions_path = Path(output_dir) / f"{model_name}.csv"
 
     # Save dataset map only at the beginning:
     if model == 0:

--- a/predict.py
+++ b/predict.py
@@ -213,7 +213,12 @@ def main(args):
     assert (
         args.batch_size > 0
     ), f"Batch size must be higher than 0 but got {args.batch_size}"
-    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+    if not Path(args.output_dir).exists():
+        user_response = input(f"The directory '{args.output_dir}' does not exist. Do you want to create it? [y/n]: ")
+        if user_response.lower() == 'y':
+            Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+        else:
+            return
     (
         flat_dataset_map,
         pdb_to_sequence,

--- a/predict.py
+++ b/predict.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 from math import ceil
 from pathlib import Path
 
@@ -119,10 +118,7 @@ def load_dataset_and_predict(
         # Import Model:
         frame_model = tf.keras.models.load_model(Path(m))
         # Create output file for model:
-        model_out = os.path.join(
-            output_dir,
-            f"{model_name}_rot.csv" if predict_rotamers else f"{model_name}.csv"
-        )
+        model_out = Path(output_dir) / (f"{model_name}_rot.csv" if predict_rotamers else f"{model_name}.csv")
         # Load batch:
         for index in tqdm(
             range(start_batch, n_batches),
@@ -217,7 +213,7 @@ def main(args):
     assert (
         args.batch_size > 0
     ), f"Batch size must be higher than 0 but got {args.batch_size}"
-    os.makedirs(args.output_dir, exist_ok=True)
+    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
     (
         flat_dataset_map,
         pdb_to_sequence,
@@ -245,7 +241,7 @@ if __name__ == "__main__":
         "--output_dir",
         type=str,
         default=".",
-        help="Directory to save output files"
+        help="Directory to save output files. Defaults to current working directory."
     )
     parser.add_argument(
         "--batch_size",


### PR DESCRIPTION
Fixed an issue where some outputs were placed in cwd, and some in parent directory which is not always accessible. 

--output_dir is "." by default and can be specified to any desired folder. The folder will be created if it does not exist.

