### PR TITLE
multi chain output format

### DIFF
--- a/design_utils/utils.py
+++ b/design_utils/utils.py
@@ -670,15 +670,13 @@ def extract_sequence_from_pred_matrix(
             pdb, count = flat_dataset_map[i]
             count = int(count)
         # TODO: this line is not elegant in the way it handles 4 letter codes as PDB codes. It might lead to problems later on
-        if len(pdb) == 4:
-            pdbchain = pdb[:4] + "A"
-        else:
-            pdbchain = pdb
+
+        pdb += chain
         # Prepare the dictionaries:
-        if pdbchain not in pdb_to_sequence:
-            pdb_to_sequence[pdbchain] = ""
-            pdb_to_real_sequence[pdbchain] = ""
-            pdb_to_probability[pdbchain] = []
+        if pdb not in pdb_to_sequence:
+            pdb_to_sequence[pdb] = ""
+            pdb_to_real_sequence[pdb] = ""
+            pdb_to_probability[pdb] = []
         # Loop through map:
         for n in range(previous_count, previous_count + count):
             if old_datasetmap:
@@ -688,10 +686,10 @@ def extract_sequence_from_pred_matrix(
 
             pred = list(prediction_matrix[idx])
             curr_res = res_dic[max_idx[idx]]
-            pdb_to_probability[pdbchain].append(pred)
-            pdb_to_sequence[pdbchain] += curr_res
+            pdb_to_probability[pdb].append(pred)
+            pdb_to_sequence[pdb] += curr_res
             if old_datasetmap:
-                pdb_to_real_sequence[pdbchain] += res_to_r_dic[res]
+                pdb_to_real_sequence[pdb] += res_to_r_dic[res]
         if not old_datasetmap:
             previous_count += count
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TIMED-Design"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">= 3.8"
 description = "TIMED-Design is a library to use protein sequence design models and analyse predictions."
 readme = "README.md"


### PR DESCRIPTION
At the moment, TIMED takes a multi-chain structure and gives the output by merging these chains together in a single chain format. For example, for a 368 aa protein consisting of 184 aa in chain A and 184 aa in chain B, we would like to have the output fasta to show predictions for individual chains. At the moment, we get single prediction for chain A with a length of 368.

This code overcomes this problem.