### PR TITLE
Fix residues

### DIFF
--- a/design_utils/utils.py
+++ b/design_utils/utils.py
@@ -669,8 +669,6 @@ def extract_sequence_from_pred_matrix(
         else:
             pdb, count = flat_dataset_map[i]
             count = int(count)
-        # TODO: this line is not elegant in the way it handles 4 letter codes as PDB codes. It might lead to problems later on
-
         pdb += chain
         # Prepare the dictionaries:
         if pdb not in pdb_to_sequence:

--- a/design_utils/utils.py
+++ b/design_utils/utils.py
@@ -670,15 +670,13 @@ def extract_sequence_from_pred_matrix(
             pdb, count = flat_dataset_map[i]
             count = int(count)
         # TODO: this line is not elegant in the way it handles 4 letter codes as PDB codes. It might lead to problems later on
-        if len(pdb) == 4:
-            pdbchain = pdb[:4] + "A"
-        else:
-            pdbchain = pdb
+
+        pdb += chain
         # Prepare the dictionaries:
-        if pdbchain not in pdb_to_sequence:
-            pdb_to_sequence[pdbchain] = ""
-            pdb_to_real_sequence[pdbchain] = ""
-            pdb_to_probability[pdbchain] = []
+        if pdb not in pdb_to_sequence:
+            pdb_to_sequence[pdb] = ""
+            pdb_to_real_sequence[pdb] = ""
+            pdb_to_probability[pdb] = []
         # Loop through map:
         for n in range(previous_count, previous_count + count):
             if old_datasetmap:
@@ -688,10 +686,10 @@ def extract_sequence_from_pred_matrix(
 
             pred = list(prediction_matrix[idx])
             curr_res = res_dic[max_idx[idx]]
-            pdb_to_probability[pdbchain].append(pred)
-            pdb_to_sequence[pdbchain] += curr_res
+            pdb_to_probability[pdb].append(pred)
+            pdb_to_sequence[pdb] += curr_res
             if old_datasetmap:
-                pdb_to_real_sequence[pdbchain] += res_to_r_dic[res]
+                pdb_to_real_sequence[pdb] += res_to_r_dic[res]
         if not old_datasetmap:
             previous_count += count
 

--- a/design_utils/utils.py
+++ b/design_utils/utils.py
@@ -664,17 +664,17 @@ def extract_sequence_from_pred_matrix(
         chain = None
         # Add support for different dataset maps:
         if old_datasetmap:
-            pdb, chain, _, res = flat_dataset_map[i]
+            pdb_chain, chain, _, res = flat_dataset_map[i]
             count = 1
         else:
-            pdb, count = flat_dataset_map[i]
+            pdb_chain, count = flat_dataset_map[i]
             count = int(count)
-        pdb += chain
+        pdb_chain += chain
         # Prepare the dictionaries:
-        if pdb not in pdb_to_sequence:
-            pdb_to_sequence[pdb] = ""
-            pdb_to_real_sequence[pdb] = ""
-            pdb_to_probability[pdb] = []
+        if pdb_chain not in pdb_to_sequence:
+            pdb_to_sequence[pdb_chain] = ""
+            pdb_to_real_sequence[pdb_chain] = ""
+            pdb_to_probability[pdb_chain] = []
         # Loop through map:
         for n in range(previous_count, previous_count + count):
             if old_datasetmap:
@@ -684,33 +684,33 @@ def extract_sequence_from_pred_matrix(
 
             pred = list(prediction_matrix[idx])
             curr_res = res_dic[max_idx[idx]]
-            pdb_to_probability[pdb].append(pred)
-            pdb_to_sequence[pdb] += curr_res
+            pdb_to_probability[pdb_chain].append(pred)
+            pdb_to_sequence[pdb_chain] += curr_res
             if old_datasetmap:
-                pdb_to_real_sequence[pdb] += res_to_r_dic[res]
+                pdb_to_real_sequence[pdb_chain] += res_to_r_dic[res]
         if not old_datasetmap:
             previous_count += count
 
     if is_consensus:
         last_pdb = ""
         # Sum up probabilities:
-        for pdb in pdb_to_sequence.keys():
-            curr_pdb = pdb.split("_")[0]
+        for pdb_chain in pdb_to_sequence.keys():
+            curr_pdb = pdb_chain.split("_")[0]
             if last_pdb != curr_pdb:
-                pdb_to_consensus_prob[curr_pdb] = np.array(pdb_to_probability[pdb])
+                pdb_to_consensus_prob[curr_pdb] = np.array(pdb_to_probability[pdb_chain])
                 last_pdb = curr_pdb
             else:
                 pdb_to_consensus_prob[curr_pdb] = (
-                    pdb_to_consensus_prob[curr_pdb] + np.array(pdb_to_probability[pdb])
+                    pdb_to_consensus_prob[curr_pdb] + np.array(pdb_to_probability[pdb_chain])
                 ) / 2
         # Extract sequences from consensus probabilities:
-        for pdb in pdb_to_consensus_prob.keys():
-            pdb_to_consensus[pdb] = ""
-            curr_prob = pdb_to_consensus_prob[pdb]
+        for pdb_chain in pdb_to_consensus_prob.keys():
+            pdb_to_consensus[pdb_chain] = ""
+            curr_prob = pdb_to_consensus_prob[pdb_chain]
             max_idx = np.argmax(curr_prob, axis=1)
             for m in max_idx:
                 curr_res = res_dic[m]
-                pdb_to_consensus[pdb] += curr_res
+                pdb_to_consensus[pdb_chain] += curr_res
 
         return (
             pdb_to_sequence,

--- a/predict.py
+++ b/predict.py
@@ -1,6 +1,8 @@
 import argparse
+from ast import Str, Tuple
 from math import ceil
 from pathlib import Path
+from re import T
 
 import numpy as np
 import tensorflow as tf
@@ -21,6 +23,22 @@ from design_utils.utils import (
 )
 
 
+def parse_residue_list(residue_list):
+    try:
+        lists = residue_list.split(",")
+        return [tuple(int(residue) for residue in sublist.split()) for sublist in lists]
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid residue list: {residue_list}")
+
+
+def parse_chain_list(chain_list):
+    try:
+        chains = chain_list.split(",")
+        return [(chain.strip()) for chain in chains]
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid residue list: {chain_list}")
+
+
 def top_3_cat_acc(y_true, y_pred):
     return top_k_categorical_accuracy(y_true, y_pred, k=3)
 
@@ -28,6 +46,9 @@ def top_3_cat_acc(y_true, y_pred):
 def load_dataset_and_predict(
     models: list,
     dataset_path: Path,
+    res_to_predict: Tuple,
+    res_to_fix: Tuple,
+    chains_to_customize: Tuple,
     batch_size: int = 20,
     start_batch: int = 0,
     dataset_map_path: Path = "datasetmap.txt",
@@ -49,6 +70,16 @@ def load_dataset_and_predict(
         List of paths to the models to be used for the ensemble
     dataset_path: Path
         Path to the dataset with frames.
+    res_to_predict: Tuple
+        Residues that will be predicted by TIMED in a specified chain. Unspecified chains and rest of the residues
+        in a specified chain will be kept same as WT.
+    res_to_fix:
+        Residues that will be kept the same as WT in a specified chain. Unspecified chains and rest of the residues
+        in a specified chain will be predicted normally by TIMED.
+    chains_to_customize:
+        Chains that will be considered for the customized prediction. If chains are specified with --res_to_predict, then
+        such residues in a given chain will be predicted and rest will be same as WT. If used with --res_to_fix, then such
+        residues in a given chain will be same as WT and rest will be predicted normally by TIMED.
     batch_size: int
         Number of frames to be looked predicted at once.
     start_batch:
@@ -67,7 +98,7 @@ def load_dataset_and_predict(
         Whether the structure is NMR and the prediction should be a consensus of all the states
     path_to_output: Path
         Path to output directory. Defaults to current working directory.
-        
+
     Returns
     -------
     flat_dataset_map: t.List[t.Tuple]
@@ -120,7 +151,11 @@ def load_dataset_and_predict(
         # Import Model:
         frame_model = tf.keras.models.load_model(Path(m))
         # Create output file for model:
-        model_out = path_to_output / ("{model_name}" + "_rot.csv" if predict_rotamers else f"{model_name}" + ".csv")
+        model_out = path_to_output / (
+            "{model_name}" + "_rot.csv"
+            if predict_rotamers
+            else f"{model_name}" + ".csv"
+        )
         # Load batch:
         for index in tqdm(
             range(start_batch, n_batches),
@@ -134,10 +169,7 @@ def load_dataset_and_predict(
             current_batch_map = flat_dataset_map[
                 index * batch_size : (index + 1) * batch_size
             ]
-            X_batch, y_true_batch = load_batch(
-                dataset_path,
-                current_batch_map,
-            )
+            X_batch, y_true_batch = load_batch(dataset_path, current_batch_map)
             # Make Predictions
             y_pred_batch = frame_model.predict(X_batch)
             if predict_rotamers:
@@ -152,7 +184,9 @@ def load_dataset_and_predict(
             # Save current labels:
             y_true.extend(y_true_batch)
             # Save to output file:
-            save_outputs_to_file(y_true, y_pred, flat_dataset_map, i, model_name, path_to_output)
+            save_outputs_to_file(
+                y_true, y_pred, flat_dataset_map, i, model_name, path_to_output
+            )
             # Reset to avoid memory errors
             del y_true
             del y_pred
@@ -170,6 +204,9 @@ def load_dataset_and_predict(
             pdb_to_consensus_prob,
         ) = extract_sequence_from_pred_matrix(
             flat_dataset_map,
+            res_to_predict,
+            res_to_fix,
+            chains_to_customize,
             prediction_matrix,
             rotamers_categories=flat_categories if predict_rotamers else None,
             old_datasetmap=old_datasetmap,
@@ -178,10 +215,7 @@ def load_dataset_and_predict(
         save_dict_to_fasta(pdb_to_sequence, model_name, path_to_output)
         save_dict_to_fasta(pdb_to_real_sequence, "dataset", path_to_output)
         if pdb_to_consensus:
-            save_dict_to_fasta(
-                pdb_to_consensus,
-                model_name + "_consensus",
-            )
+            save_dict_to_fasta(pdb_to_consensus, model_name + "_consensus")
             save_consensus_probs(pdb_to_consensus_prob, model_name, path_to_output)
 
     return (
@@ -237,6 +271,9 @@ def main(args):
     ) = load_dataset_and_predict(
         [args.path_to_model],
         args.path_to_dataset,
+        res_to_predict=args.res_to_predict,
+        res_to_fix=args.res_to_fix,
+        chains_to_customize=args.chains_for_customized_prediction,
         batch_size=args.batch_size,
         start_batch=0,
         blacklist=args.path_to_blacklist,
@@ -294,5 +331,30 @@ if __name__ == "__main__":
         action="store_true",
         help="Whether the structure is NMR. NMR will have different states so TIMED will try to build a consensus",
     )
+
+    parser.add_argument(
+        "--res_to_fix",
+        type=parse_residue_list,
+        help="Specify the residue numbers that need to be fixed, separated by commas. Example: '2 3 4 5, 6 7 8' will keep 2 3 4 5 6 7 8th residues as identical with WT and predict the rest.",
+    )
+
+    parser.add_argument(
+        "--chains_for_customized_prediction",
+        type=parse_chain_list,
+        help="Specify the chains need to be fixed, separated by commas. Example: 'A, B' ",
+    )
+
+    parser.add_argument(
+        "--res_to_predict",
+        type=parse_residue_list,
+        help="Specify the residue numbers that need to be predicted, separated by commas. Example: '2 3 4 5, 6 7 8' will predict 2 3 4 5 6 7 8th residues and leave the rest as same as WT",
+    )
+
+    parser.add_argument(
+        "--chains_to_predict",
+        type=parse_chain_list,
+        help="Specify the chains that will be used in the customized prediction, separated by commas. Example: 'A, B ' will apply the fixing or predicting of specific aminoacids to these chains. Unspecified chains will be predicted normally by TIMED.",
+    )
+
     params = parser.parse_args()
     main(params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TIMED-Design"
-version = "1.0.1"
+version = "1.1.0"
 requires-python = ">= 3.8"
 description = "TIMED-Design is a library to use protein sequence design models and analyse predictions."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,4 @@ dependencies = [
     "tensorflow==2.13.0",
     "tqdm==4.64.0"
 ]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,3 @@ dependencies = [
     "tensorflow==2.13.0",
     "tqdm==4.64.0"
 ]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TIMED-Design"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">= 3.8"
 description = "TIMED-Design is a library to use protein sequence design models and analyse predictions."
 readme = "README.md"


### PR DESCRIPTION
At the moment, TIMED predicts all the residues for a given protein. However, it appears that there is a demand for being able to fix some residues on a given protein, such as here:

https://github.com/wells-wood-research/timed-design/issues/78

This PR enables the user to:

a) Fix residues on specified chains, on multiple structures to the WT aminoacids. When this is done, everything except the specified residues on specified chains will be PREDICTED BY TIMED.

b) Predict residues on specified chains. When this is used, everything except the specified residues on specified chains will be KEPT THE SAME AS WT.

There is a need for improvement though. For example, we can customize the fixing of residues even further by feeding some sort of a csv file, first column being the pdb name and second column being the residue numbers. As it is, the feature assumes that we always want to fix the same residues in all proteins in a given folder. However, this is rarely the case.Still, the path for achieving this seems clear to me, and can be implemented easily.