### PR TITLE
Resfix respredict

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Or if we want to fix the residue number 3, 4, and 5:
 If we want to fix residues from multiple chains, such as 3, 4 and 5 from chain A and 2, 3, 4 from chain B:
 
 ```
- python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_fix "3 4 5, 2 3 4" --chains_to_predict "A, B"
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_fix "3 4 5, 2 3 4" --chains_to_fix "A, B"
 
 ```
 
@@ -275,7 +275,7 @@ Or if we want to predict the residue number 3, 4, and 5:
 If we want to predict residues from multiple chains, such as 3, 4 and 5 from chain A and 2, 3, 4 from chain B:
 
 ```
- python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_fix "3 4 5, 2 3 4" --chains_to_fix "A, B"
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_predict "3 4 5, 2 3 4" --chains_to_predict "A, B"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h2>Protein Sequence Design Made Easy</h2><br>
 <a href="https://doi.org/10.1093/protein/gzae002"><img src="https://zenodo.org/badge/DOI/10.1093/protein/gzae002.svg" alt="DOI"></a>
 
-  
+
 ![Demo Animation](https://raw.githubusercontent.com/universvm/timed-gif/main/demo.gif)
 
 </div>
@@ -56,7 +56,7 @@ pip install .
 this workaround to work:
 
 ```
-conda install cudatoolkit cudnn cupti 
+conda install cudatoolkit cudnn cupti
 export PATH=/usr/local/cuda/bin:$PATH
 pip install nvidia-cudnn-cu11==8.6.0.163
 CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))
@@ -70,9 +70,9 @@ python3 -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'
 
 **File**: `predict.py`
 
-**Description**:  
+**Description**:
 
-Use any model to predict a 3D structure. This requires a backbone in a .pdb structure. The side-chains of the residues will be automatically removed by [aposteriori](https://github.com/wells-wood-research/aposteriori), thus the prediction will be performed uniquely on the empty backbone. Your chosen model will attempt to predict which residues best fit the position and will return a `.fasta` file as well as a probability distribution in `.csv` format. 
+Use any model to predict a 3D structure. This requires a backbone in a .pdb structure. The side-chains of the residues will be automatically removed by [aposteriori](https://github.com/wells-wood-research/aposteriori), thus the prediction will be performed uniquely on the empty backbone. Your chosen model will attempt to predict which residues best fit the position and will return a `.fasta` file as well as a probability distribution in `.csv` format.
 
 ### 1.2 Design a Sequence
 
@@ -86,7 +86,7 @@ make-frame-dataset $YOUR_PDB_FOLDER  -e $YOUR_PDB_EXTENSION --voxels-per-side 21
 
 `$YOUR_PDB_FOLDER` is a path to your folders containing PDB files. These need to be all with the same format (e.g. `.pdb`)
 
-`$YOUR_PDB_EXTENSION` is the file extension of your PDB files in `$YOUR_PDB_FOLDER` 
+`$YOUR_PDB_EXTENSION` is the file extension of your PDB files in `$YOUR_PDB_FOLDER`
 
  `$YOUR_CODEC` This will normally be `CNOCBCA` except for TIMED_Charge `CNOCBCAQ` and TIMED_Polar `CNOCBCAP`
 
@@ -101,9 +101,9 @@ make-frame-dataset tests/testing_files -e .pdb1.gz --name data --voxels-per-side
 
 https://github.com/wells-wood-research/timed-design/releases
 
-For example, download TIMED.h5 . Make sure to place it in this directory. 
+For example, download TIMED.h5 . Make sure to place it in this directory.
 
-4. Finally run: 
+4. Finally run:
 
 
 ```
@@ -147,7 +147,7 @@ docker run -v /local/path/to/models/:/scratch/timed_dataset/models -v /local/pat
 Enter the directory if you are not:
 
 ```
-cd timed-design 
+cd timed-design
 ```
 
 Install with pip:
@@ -161,27 +161,27 @@ pip install .
 ## 2. Sample Sequences Using Monte Carlo
 
 **File**: `sample.py`
-**Description**:  
+**Description**:
 
 Uses Monte Carlo sampling to sample sequences from a  probability distribution. A temperature factor can be applied to affect the distributions. It will return a `.fasta` file and/or a `.json` file with the sequences and a `.csv` file with basic sequence metrics such as isoelectric point, molecular weight and charge. Further metrics can be calculated using NetSolP-1.0 (see `scripts/run_netsolp.sh`).
 
 ## 3. Analyse Rotamer Predictions
 
 **File**: `analyse_rotamers.py`
-**Description**:  
+**Description**:
 
 ---Under construction---
 
 
 ## 4. Background
 
-Proteins are macro-molecules present in all living organisms (and viruses). They are involved in important chemical reactions in metabolism, DNA replication and also have structural properties. 
+Proteins are macro-molecules present in all living organisms (and viruses). They are involved in important chemical reactions in metabolism, DNA replication and also have structural properties.
 
 The 3D shape of the protein defines its function. Proteins are made of twenty subunits called amino acids (or residues), all of which have different atomic structures and chemical properties. Different combinations of amino acids produce different 3D shapes.
 
 The **Protein Folding Problem** aims at identifying the 3D shape of a protein based solely on the sequence of amino acid. This problem is being tackled by models like **AlphaFold2** by Google Deep Mind.
 
-The other side of this problem is the **Inverse Folding Problem** (Protein Sequence Design), that is, given a desired 3D structure with a useful function, identify the residue sequence that will reliably fold into this structure. This problem is arguably harder, as multiple sequence of amino acids can fit the same 3D shape. 
+The other side of this problem is the **Inverse Folding Problem** (Protein Sequence Design), that is, given a desired 3D structure with a useful function, identify the residue sequence that will reliably fold into this structure. This problem is arguably harder, as multiple sequence of amino acids can fit the same 3D shape.
 
 Nature evolves by natural selection (depth first search), thus, the protein sequences sampled in nature account for a tiny fraction of all physically possible proteins. Even for a relatively small protein with around **200 amino acids**, there are around **10^260 possible sequences**, which is significantly more than that have been sampled in every cell of every organism since proteins arose. There are therefore many 3D shapes of proteins that are physically possible, potentially useful, which have not been explored by nature. Protein designers aim at unlocking the potential of this pool of unobserved proteins, known as the **dark matter of protein folding space**.
 
@@ -196,7 +196,7 @@ TIMED (Three-dimensional Inference Method for Efficient Design) is a Convolution
 
 The input of the model is a cube of gridded, voxelised space (a "Frame") around each amino acid position of the backbone. The alpha Carbon is centered in the frame, and the frame is rotated so that the Alpha Carbon to Carbon bond lies along the x-axis. Each atom (C, N, O, alpha-C, beta-C) is one-hot-encoded in a different channel, thus producing a 4D array. The beta-Carbon position is hard-coded to the average position of all beta-Carbon in the protein 1QYS after the aforementioned rotations.
 
-For a 100-amino-acid protein we therefore generate 100 frames of equal width, height and length and feed them to our models. To produce these frames we use a library we developed called [aposteriori](https://github.com/wells-wood-research/aposteriori). 
+For a 100-amino-acid protein we therefore generate 100 frames of equal width, height and length and feed them to our models. To produce these frames we use a library we developed called [aposteriori](https://github.com/wells-wood-research/aposteriori).
 
 The output of our models is a probability distribution over all amino acids at each position. For instance, at each position the models output a probability over every residue being at that position. For a 100-amino-acid protein will have an output of shape (100, 20) as there are twenty amino acids:
 
@@ -206,7 +206,7 @@ The output of our models is a probability distribution over all amino acids at e
 
 #### TIMED Architecture
 
-The TIMED architecture features a Convolutional Block composed of a 3D Convolution Operation, followed by ELU Activation and Batch Normalisation. We feature several convolution blocks which end with Spatial Dropout and a Global Average Pooling layer rather than a Dense layer. The output of the softmax layer is either 20 (for the 20 residues) or 338 (for rotamers). The architecture is illustrated below 
+The TIMED architecture features a Convolutional Block composed of a 3D Convolution Operation, followed by ELU Activation and Batch Normalisation. We feature several convolution blocks which end with Spatial Dropout and a Global Average Pooling layer rather than a Dense layer. The output of the softmax layer is either 20 (for the 20 residues) or 338 (for rotamers). The architecture is illustrated below
 
 <div align="center">
   <img src="img/timed_architecture.png"><br>
@@ -218,7 +218,7 @@ The TIMED architecture features a Convolutional Block composed of a 3D Convoluti
 
 Amino acids are made of chemical bonds that can rotate in space, thus resulting in a different spacial configuration of the residue. These are called **Rotational Isomers (Rotamers)**, and longer residues like Lysine (K), tend to have more rotamers.
 
-Rather than predicting 20 amino acid, we built models to predict both the amino acid AND the rotamer configuration in space. Therefore, for one frame our model identifies both, the amino acid identity and its predicted conformation in space: 
+Rather than predicting 20 amino acid, we built models to predict both the amino acid AND the rotamer configuration in space. Therefore, for one frame our model identifies both, the amino acid identity and its predicted conformation in space:
 
 <div align="center">
   <img src="img/rotamer_pred.png"><br>
@@ -226,13 +226,87 @@ Rather than predicting 20 amino acid, we built models to predict both the amino 
 
 The rotamer models therefore predict 338 classes rather than 20. **Rotamer models** tend to significantly **outperform conventional models**, even with the **same network structure**, while also providing increased granularity of predictions which can then be further refined using molecular dynamics simulations.
 
-We are the first in the field to validate rotamer models and provide them and various implementation of other models, free for use. 
+We are the first in the field to validate rotamer models and provide them and various implementation of other models, free for use.
 
 ### Monte Carlo Sampling
 
-As the output of our models is a probability distribution, an alternative to picking the amino acid with the highest probability (argmax), is to sample from the probability distribution using methods like Monte Carlo. For one protein shape we can therefore generate several sequences that can then be screened for specific properties like charge, isoelectric point, solubility, and expressivity. 
+As the output of our models is a probability distribution, an alternative to picking the amino acid with the highest probability (argmax), is to sample from the probability distribution using methods like Monte Carlo. For one protein shape we can therefore generate several sequences that can then be screened for specific properties like charge, isoelectric point, solubility, and expressivity.
 
 We provide a simple CLI interface to generate several of these design which output to a `.fasta` file.
+
+### Fixing/predicting specific residues
+
+Sometimes a user may wish to keep certain aminoacid positions same as in the input structure, and only predict the others. For example, a priori knowledge that a certain aminoacid on a given protein is crucial for it's folding, stability, or function may render fixing of such residues desirable. By using --res_to_fix or --res_to_predict flags, the users may choose which aminoacids to "fix", or to "predict". We recommend using the --res_to_fix flag if there are low number of residues you would like to fix. --res_to_predict may be more handy in case a low number of aminoacids are to be predicted, when keeping the rest of the protein as it is in the input.
+
+For example, if we want to fix the residue number 3 on a given protein in the chain A, we can run the following:
+
+```
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_fix "3" --chains_to_fix "A"
+
+```
+Or if we want to fix the residue number 3, 4, and 5:
+
+```
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_fix "3 4 5" --chains_to_fix "A"
+
+```
+
+If we want to fix residues from multiple chains, such as 3, 4 and 5 from chain A and 2, 3, 4 from chain B:
+
+```
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_fix "3 4 5, 2 3 4" --chains_to_predict "A, B"
+
+```
+
+If we want to predict only the residue number 3 on a given protein in the chain A:
+
+```
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_predict "3" --chains_to_predict "A"
+
+```
+
+Or if we want to predict the residue number 3, 4, and 5:
+
+```
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_predict "3 4 5" --chains_to_predict "A"
+
+```
+
+If we want to predict residues from multiple chains, such as 3, 4 and 5 from chain A and 2, 3, 4 from chain B:
+
+```
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_fix "3 4 5, 2 3 4" --chains_to_fix "A, B"
+
+```
+
+Moreover, we can apply constraints over certain residues on the protein in terms of the aminoacid identity. For example, maybe we would like to have several pre-defined mutations on specific positions of the protein. In this case, TIMED will give an output where this constraint is applied to give the mutant at a given position. For example, if we want to have a tyrosine at residue number 3 in the chain A and serine at residue number 4 in the chain B of a protein:
+
+```
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_fix "3Y, 4S" --chains_to_fix "A, B"
+
+```
+
+Or we may want to apply these mutations but also keep the residue number 5 on chain A and  residue number 10 on chain B same as WT:
+
+
+```
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_fix "3Y 5, 4S, 10" --chains_to_fix "A, B"
+
+```
+
+There may be cases where we want to keep most of the structure as WT, but only predict few aminoacids. For example, we may want to predict only the residue number 10 on chain A, and constrain the residue number 3 to be a tyrosine. For chain B, we may want to predict only the residue number 15 and apply a point mutation the residue number 4 to make it a serine:
+
+
+```
+ python3 predict.py --path_to_dataset {YOUR_DATASET}.hdf5 --path_to_model {YOUR_TIMED_MODEL}.h5 --path_to_output . --res_to_fix "3Y, 4S" --chains_to_fix "A, B" --res_to_predict "10, 15" --chains_to_predict "A, B"
+
+```
+
+
+These flags can also be used with multiple structures in a given directory. For example, if you would like to predict sequences for a given protein at different stages of a molecular dynamics (MD) simulations, you can collect such pdb states in a single folder and predict them high-throughput.
+
+NOTE: It is important to note that the tool expects the numbers for --res_to_fix and --res_to_predict as they appear in the PDB. For example, if you would like to fix the first aminoacid in a PDB structure, but the number for that aminoacid in PDB is 81, the tool expects to be given 81.
+
 
 ## 5. Cite This Work
 

--- a/design_utils/utils.py
+++ b/design_utils/utils.py
@@ -669,8 +669,6 @@ def extract_sequence_from_pred_matrix(
         else:
             pdb, count = flat_dataset_map[i]
             count = int(count)
-        # TODO: this line is not elegant in the way it handles 4 letter codes as PDB codes. It might lead to problems later on
-
         pdb += chain
         # Prepare the dictionaries:
         if pdb not in pdb_to_sequence:

--- a/design_utils/utils.py
+++ b/design_utils/utils.py
@@ -670,15 +670,13 @@ def extract_sequence_from_pred_matrix(
             pdb, count = flat_dataset_map[i]
             count = int(count)
         # TODO: this line is not elegant in the way it handles 4 letter codes as PDB codes. It might lead to problems later on
-        if len(pdb) == 4:
-            pdbchain = pdb[:4] + "A"
-        else:
-            pdbchain = pdb
+
+        pdb += chain
         # Prepare the dictionaries:
-        if pdbchain not in pdb_to_sequence:
-            pdb_to_sequence[pdbchain] = ""
-            pdb_to_real_sequence[pdbchain] = ""
-            pdb_to_probability[pdbchain] = []
+        if pdb not in pdb_to_sequence:
+            pdb_to_sequence[pdb] = ""
+            pdb_to_real_sequence[pdb] = ""
+            pdb_to_probability[pdb] = []
         # Loop through map:
         for n in range(previous_count, previous_count + count):
             if old_datasetmap:
@@ -688,10 +686,10 @@ def extract_sequence_from_pred_matrix(
 
             pred = list(prediction_matrix[idx])
             curr_res = res_dic[max_idx[idx]]
-            pdb_to_probability[pdbchain].append(pred)
-            pdb_to_sequence[pdbchain] += curr_res
+            pdb_to_probability[pdb].append(pred)
+            pdb_to_sequence[pdb] += curr_res
             if old_datasetmap:
-                pdb_to_real_sequence[pdbchain] += res_to_r_dic[res]
+                pdb_to_real_sequence[pdb] += res_to_r_dic[res]
         if not old_datasetmap:
             previous_count += count
 

--- a/design_utils/utils.py
+++ b/design_utils/utils.py
@@ -30,9 +30,9 @@ def avoid_fix_predict_simultaneously(
 
     Parameters:
     -----------
-    res_to_predict : tuple
+    res_to_predict : t.Tuple[t.Tuple]
         Tuple of tuples representing residues to be predicted.
-    res_to_fix : tuple
+    res_to_fix : t.Tuple[t.Tuple]
         Tuple of tuples representing residues to be fixed.
 
     Raises:

--- a/design_utils/utils.py
+++ b/design_utils/utils.py
@@ -664,17 +664,17 @@ def extract_sequence_from_pred_matrix(
         chain = None
         # Add support for different dataset maps:
         if old_datasetmap:
-            pdb, chain, _, res = flat_dataset_map[i]
+            pdb_chain, chain, _, res = flat_dataset_map[i]
             count = 1
         else:
-            pdb, count = flat_dataset_map[i]
+            pdb_chain, count = flat_dataset_map[i]
             count = int(count)
-        pdb += chain
+        pdb_chain += chain
         # Prepare the dictionaries:
-        if pdb not in pdb_to_sequence:
-            pdb_to_sequence[pdb] = ""
-            pdb_to_real_sequence[pdb] = ""
-            pdb_to_probability[pdb] = []
+        if pdb_chain not in pdb_to_sequence:
+            pdb_to_sequence[pdb_chain] = ""
+            pdb_to_real_sequence[pdb_chain] = ""
+            pdb_to_probability[pdb_chain] = []
         # Loop through map:
         for n in range(previous_count, previous_count + count):
             if old_datasetmap:
@@ -684,33 +684,33 @@ def extract_sequence_from_pred_matrix(
 
             pred = list(prediction_matrix[idx])
             curr_res = res_dic[max_idx[idx]]
-            pdb_to_probability[pdb].append(pred)
-            pdb_to_sequence[pdb] += curr_res
+            pdb_to_probability[pdb_chain].append(pred)
+            pdb_to_sequence[pdb_chain] += curr_res
             if old_datasetmap:
-                pdb_to_real_sequence[pdb] += res_to_r_dic[res]
+                pdb_to_real_sequence[pdb_chain] += res_to_r_dic[res]
         if not old_datasetmap:
             previous_count += count
 
     if is_consensus:
         last_pdb = ""
         # Sum up probabilities:
-        for pdb in pdb_to_sequence.keys():
-            curr_pdb = pdb.split("_")[0]
+        for pdb_chain in pdb_to_sequence.keys():
+            curr_pdb = pdb_chain.split("_")[0]
             if last_pdb != curr_pdb:
-                pdb_to_consensus_prob[curr_pdb] = np.array(pdb_to_probability[pdb])
+                pdb_to_consensus_prob[curr_pdb] = np.array(pdb_to_probability[pdb_chain])
                 last_pdb = curr_pdb
             else:
                 pdb_to_consensus_prob[curr_pdb] = (
-                    pdb_to_consensus_prob[curr_pdb] + np.array(pdb_to_probability[pdb])
+                    pdb_to_consensus_prob[curr_pdb] + np.array(pdb_to_probability[pdb_chain])
                 ) / 2
         # Extract sequences from consensus probabilities:
-        for pdb in pdb_to_consensus_prob.keys():
-            pdb_to_consensus[pdb] = ""
-            curr_prob = pdb_to_consensus_prob[pdb]
+        for pdb_chain in pdb_to_consensus_prob.keys():
+            pdb_to_consensus[pdb_chain] = ""
+            curr_prob = pdb_to_consensus_prob[pdb_chain]
             max_idx = np.argmax(curr_prob, axis=1)
             for m in max_idx:
                 curr_res = res_dic[m]
-                pdb_to_consensus[pdb] += curr_res
+                pdb_to_consensus[pdb_chain] += curr_res
 
         return (
             pdb_to_sequence,

--- a/predict.py
+++ b/predict.py
@@ -74,16 +74,16 @@ def load_dataset_and_predict(
     res_to_predict: Tuple
         Residues that will be predicted by TIMED in a specified chain. Unspecified chains and rest of the residues
         in a specified chain will be kept same as WT.
-    res_to_fix:
+    res_to_fix: Tuple
         Residues that will be kept the same as WT in a specified chain. Unspecified chains and rest of the residues
         in a specified chain will be predicted normally by TIMED.
-    chains_to_fix:
+    chains_to_fix: Tuple
         To be used in combination with --res_to_fix. Chains that will be used for residue fixing. Unchosen residues and unchosen chains will be predicted normally by TIMED
-    chains_to_predict:
+    chains_to_predict: Tuple
         To be used in combination with --res_to_predict. All the residues in the unchosen chains will be reverted to WT (unless --res_to_fix and --chains_to_fix are not used for such chains and residues).
     batch_size: int
         Number of frames to be looked predicted at once.
-    start_batch:
+    start_batch: int
         Which batch to start from. In case the code crashes you can check which
         was the last batch used and restart from there. Make sure you remove the
         other models from the paths to be used.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,4 @@ dependencies = [
     "tensorflow==2.13.0",
     "tqdm==4.64.0"
 ]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,3 @@ dependencies = [
     "tensorflow==2.13.0",
     "tqdm==4.64.0"
 ]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TIMED-Design"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">= 3.8"
 description = "TIMED-Design is a library to use protein sequence design models and analyse predictions."
 readme = "README.md"


### PR DESCRIPTION
We want to enable customized predictions coming out of TIMED. With this PR, the following can be rendered possible:

-Fixing certain aminoacid positions to the consensus aminoacid
-Predicting only specific aminoacid positions and reverting rest to the consensus sequence.
-Fix certain aminoacid positions to the desired aminoacid

Relevant README updates have been added.